### PR TITLE
de-mean x before fitting to t distribution

### DIFF
--- a/sharpeRratio/R/estimateSNR.R
+++ b/sharpeRratio/R/estimateSNR.R
@@ -19,7 +19,7 @@ estimateSNR=function(x,numPerm=1000){
     return(NULL)
   }
   
-  myfit=tryCatch(fit.tuv(as.numeric(x),silent=TRUE,nu=6),error=function(e){print(e);return(NA)})
+  myfit=tryCatch(fit.tuv(as.numeric(x) - mean(as.numeric(x),na.rm=TRUE),silent=TRUE,nu=6),error=function(e){print(e);return(NA)})
   
   if(!class(myfit)=="mle.ghyp"){
     list(nu=NA,SNR=NA,R0bar=NA,N=length(x))


### PR DESCRIPTION
While the `fit.tuv` procedure can, in theory, deal with an offset via the `mu` parameter,
the fitting of `nu` should give the same results independently of the empirical mean.
Subtracting the empirical mean makes the procedure more robust.